### PR TITLE
Add branded icon to mdv GUI

### DIFF
--- a/cmd/mdv-gui/frontend/index.html
+++ b/cmd/mdv-gui/frontend/index.html
@@ -5,6 +5,7 @@
   <meta name="color-scheme" content="dark light">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>mdv</title>
+  <link rel="icon" type="image/png" href="assets/mdv-app-icon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/cmd/mdv-gui/wails.json
+++ b/cmd/mdv-gui/wails.json
@@ -19,5 +19,16 @@
   },
   "nsisType": "multiple",
   "obfuscated": false,
-  "wailsjsdir": "./frontend"
+  "wailsjsdir": "./frontend",
+  "platforms": {
+    "darwin": {
+      "icon": "./frontend/assets/mdv-app-icon.png"
+    },
+    "linux": {
+      "icon": "./frontend/assets/mdv-app-icon.png"
+    },
+    "windows": {
+      "icon": "./frontend/assets/mdv-app-icon.png"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add the mdv logo asset reference to the GUI frontend so it loads the branded favicon when provided
- configure the Wails project to package the new icon on every platform
- remove the committed mdv logo binary asset so it can be supplied externally

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5639cfdd4832b9f04cc032d0b2f6d