### PR TITLE
Add thorough configuration and rendering unit tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,297 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func withTempWorkingDir(t *testing.T) func() {
+	t.Helper()
+	tempDir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change working directory: %v", err)
+	}
+	return func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}
+}
+
+func TestNewViperDefaults(t *testing.T) {
+	restore := withTempWorkingDir(t)
+	defer restore()
+
+	t.Setenv("EDITOR", "")
+	configHome := filepath.Join(t.TempDir(), "config-home")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	v := NewViper()
+
+	if got := v.GetString("theme"); got != "auto" {
+		t.Fatalf("expected default theme 'auto', got %q", got)
+	}
+	if got := v.GetString("gui-theme"); got != "auto" {
+		t.Fatalf("expected default gui-theme 'auto', got %q", got)
+	}
+	if got := v.GetString("gui-width"); got != "medium" {
+		t.Fatalf("expected default gui-width 'medium', got %q", got)
+	}
+	if got := v.GetInt("wrap"); got != 80 {
+		t.Fatalf("expected default wrap 80, got %d", got)
+	}
+	if got := v.GetBool("gui"); got {
+		t.Fatalf("expected default gui false, got true")
+	}
+	if got := v.GetBool("watch"); got {
+		t.Fatalf("expected default watch false, got true")
+	}
+	if got := v.GetStringSlice("exclude"); len(got) != 0 {
+		t.Fatalf("expected default exclude to be empty, got %v", got)
+	}
+	if got := v.GetString("editor"); got != "vim" {
+		t.Fatalf("expected default editor 'vim', got %q", got)
+	}
+}
+
+func TestNewViperEnvironmentOverrides(t *testing.T) {
+	restore := withTempWorkingDir(t)
+	defer restore()
+
+	t.Setenv("EDITOR", "micro")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+	t.Setenv("MDV_THEME", "dark")
+	t.Setenv("MDV_WRAP", "120")
+	t.Setenv("MDV_GUI", "true")
+	t.Setenv("MDV_WATCH", "true")
+	t.Setenv("MDV_EXCLUDE", "vendor,.git")
+	t.Setenv("MDV_EDITOR", "nano")
+
+	v := NewViper()
+
+	if got := v.GetString("theme"); got != "dark" {
+		t.Fatalf("expected theme from env 'dark', got %q", got)
+	}
+	if got := v.GetInt("wrap"); got != 120 {
+		t.Fatalf("expected wrap from env 120, got %d", got)
+	}
+	if got := v.GetBool("gui"); !got {
+		t.Fatalf("expected gui from env true, got false")
+	}
+	if got := v.GetBool("watch"); !got {
+		t.Fatalf("expected watch from env true, got false")
+	}
+	if got := v.GetStringSlice("exclude"); strings.Join(got, ",") != "vendor,.git" {
+		t.Fatalf("expected exclude slice from env to contain vendor and .git, got %v", got)
+	}
+	if got := v.GetString("editor"); got != "nano" {
+		t.Fatalf("expected editor from env 'nano', got %q", got)
+	}
+}
+
+func TestBindFlagsPrecedence(t *testing.T) {
+	v := NewViper()
+
+	fs := pflag.NewFlagSet("mdv", pflag.ContinueOnError)
+	fs.String("theme", "auto", "")
+	fs.String("gui-theme", "auto", "")
+	fs.String("gui-width", "medium", "")
+	fs.Int("wrap", 80, "")
+	fs.Bool("gui", false, "")
+	fs.Bool("watch", false, "")
+	fs.StringSlice("exclude", []string{}, "")
+	fs.String("editor", "vim", "")
+
+	args := []string{
+		"--theme=light",
+		"--gui-theme=dark",
+		"--gui-width=wide",
+		"--wrap=100",
+		"--gui",
+		"--watch",
+		"--exclude=vendor",
+		"--exclude=.git",
+		"--editor=micro",
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	if err := BindFlags(v, fs); err != nil {
+		t.Fatalf("BindFlags returned error: %v", err)
+	}
+
+	if got := v.GetString("theme"); got != "light" {
+		t.Fatalf("expected theme from flags 'light', got %q", got)
+	}
+	if got := v.GetString("gui-theme"); got != "dark" {
+		t.Fatalf("expected gui-theme from flags 'dark', got %q", got)
+	}
+	if got := v.GetString("gui-width"); got != "wide" {
+		t.Fatalf("expected gui-width from flags 'wide', got %q", got)
+	}
+	if got := v.GetInt("wrap"); got != 100 {
+		t.Fatalf("expected wrap from flags 100, got %d", got)
+	}
+	if got := v.GetBool("gui"); !got {
+		t.Fatalf("expected gui from flags true, got false")
+	}
+	if got := v.GetBool("watch"); !got {
+		t.Fatalf("expected watch from flags true, got false")
+	}
+	if got := v.GetStringSlice("exclude"); len(got) != 2 || got[0] != "vendor" || got[1] != ".git" {
+		t.Fatalf("expected exclude slice from flags, got %v", got)
+	}
+	if got := v.GetString("editor"); got != "micro" {
+		t.Fatalf("expected editor from flags 'micro', got %q", got)
+	}
+}
+
+func TestMergeDirectoryConfig(t *testing.T) {
+	restore := withTempWorkingDir(t)
+	defer restore()
+
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	v := NewViper()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".mdv.yaml")
+	content := []byte("theme: dark\nwrap: 120\nexclude:\n  - vendor\n")
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatalf("failed to write directory config: %v", err)
+	}
+
+	MergeDirectoryConfig(v, dir)
+
+	if got := v.GetString("theme"); got != "dark" {
+		t.Fatalf("expected merged theme 'dark', got %q", got)
+	}
+	if got := v.GetInt("wrap"); got != 120 {
+		t.Fatalf("expected merged wrap 120, got %d", got)
+	}
+	if got := v.GetStringSlice("exclude"); len(got) != 1 || got[0] != "vendor" {
+		t.Fatalf("expected merged exclude ['vendor'], got %v", got)
+	}
+}
+
+func TestResolveThemePath(t *testing.T) {
+	dir := t.TempDir()
+	themeFile := filepath.Join(dir, "custom.json")
+	if err := os.WriteFile(themeFile, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to write theme file: %v", err)
+	}
+
+	rel := "custom.json"
+	resolved := resolveThemePath(rel, dir)
+	if resolved != themeFile {
+		t.Fatalf("expected relative path to resolve to %q, got %q", themeFile, resolved)
+	}
+
+	nonExisting := resolveThemePath("missing.json", dir)
+	if nonExisting != "missing.json" {
+		t.Fatalf("expected missing relative path to stay unchanged, got %q", nonExisting)
+	}
+
+	abs := resolveThemePath(themeFile, dir)
+	if abs != themeFile {
+		t.Fatalf("expected absolute path to remain unchanged, got %q", abs)
+	}
+
+	tildePath := "~/custom.json"
+	resolvedTilde := resolveThemePath(tildePath, dir)
+	if resolvedTilde != tildePath {
+		t.Fatalf("expected tilde path to remain unchanged, got %q", resolvedTilde)
+	}
+}
+
+func TestDecode(t *testing.T) {
+	dir := t.TempDir()
+	themeLight := filepath.Join(dir, "light.json")
+	if err := os.WriteFile(themeLight, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to write light theme file: %v", err)
+	}
+	themeDark := filepath.Join(dir, "dark.json")
+	if err := os.WriteFile(themeDark, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to write dark theme file: %v", err)
+	}
+	guiTheme := filepath.Join(dir, "theme.css")
+	if err := os.WriteFile(guiTheme, []byte("body{}"), 0o644); err != nil {
+		t.Fatalf("failed to write gui theme file: %v", err)
+	}
+
+	v := viper.New()
+	v.Set("theme", "auto")
+	v.Set("theme-light", filepath.Base(themeLight))
+	v.Set("theme-dark", filepath.Base(themeDark))
+	v.Set("gui-theme", filepath.Base(guiTheme))
+	v.Set("gui-theme-light", "light-gui.css")
+	v.Set("gui-theme-dark", "dark-gui.css")
+	v.Set("gui-width", "wide")
+	v.Set("wrap", 100)
+	v.Set("gui", true)
+	v.Set("watch", true)
+	v.Set("exclude", []string{"vendor"})
+	v.Set("editor", "nano")
+
+	cfg, err := Decode(v, "notes.md", dir)
+	if err != nil {
+		t.Fatalf("Decode returned error: %v", err)
+	}
+
+	if cfg.Theme != "auto" {
+		t.Fatalf("expected Theme 'auto', got %q", cfg.Theme)
+	}
+	if cfg.ThemeLight != themeLight {
+		t.Fatalf("expected ThemeLight resolved to %q, got %q", themeLight, cfg.ThemeLight)
+	}
+	if cfg.ThemeDark != themeDark {
+		t.Fatalf("expected ThemeDark resolved to %q, got %q", themeDark, cfg.ThemeDark)
+	}
+	expectedGUITheme, err := filepath.Abs(guiTheme)
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+	if cfg.GUITheme != expectedGUITheme {
+		t.Fatalf("expected GUITheme resolved to %q, got %q", expectedGUITheme, cfg.GUITheme)
+	}
+	if cfg.GUIWidth != "wide" {
+		t.Fatalf("expected GUIWidth 'wide', got %q", cfg.GUIWidth)
+	}
+	if cfg.Wrap != 100 {
+		t.Fatalf("expected Wrap 100, got %d", cfg.Wrap)
+	}
+	if !cfg.GUI {
+		t.Fatalf("expected GUI true, got false")
+	}
+	if !cfg.Watch {
+		t.Fatalf("expected Watch true, got false")
+	}
+	if len(cfg.Exclude) != 1 || cfg.Exclude[0] != "vendor" {
+		t.Fatalf("expected Exclude ['vendor'], got %v", cfg.Exclude)
+	}
+	if cfg.File != "notes.md" {
+		t.Fatalf("expected File 'notes.md', got %q", cfg.File)
+	}
+	if cfg.Editor != "nano" {
+		t.Fatalf("expected Editor 'nano', got %q", cfg.Editor)
+	}
+}
+
+func TestDecodeWrapValidation(t *testing.T) {
+	v := viper.New()
+	v.Set("wrap", -1)
+
+	if _, err := Decode(v, "", ""); err == nil {
+		t.Fatalf("expected error for negative wrap, got nil")
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/glamour"
@@ -18,10 +19,10 @@ import (
 
 var md = goldmark.New(
 	goldmark.WithExtensions(
-		extension.GFM,            // tables, strikethrough, task lists
-		extension.Table,          // explicit table extension (redundant, ok)
-		extension.Linkify,        // autolink URLs
-		extension.Strikethrough,  // ~~del~~
+		extension.GFM,           // tables, strikethrough, task lists
+		extension.Table,         // explicit table extension (redundant, ok)
+		extension.Linkify,       // autolink URLs
+		extension.Strikethrough, // ~~del~~
 	),
 	goldmark.WithParserOptions(
 		parser.WithAutoHeadingID(),
@@ -49,11 +50,12 @@ func detectSystemTheme() string {
 			parts := strings.Split(colorfgbg, ";")
 			if len(parts) == 2 {
 				// If background is dark (0-8), use dark theme
-				bg := parts[1]
-				if bg >= "0" && bg <= "8" {
-					return "dark"
+				if bg, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil {
+					if bg >= 0 && bg <= 8 {
+						return "dark"
+					}
+					return "light"
 				}
-				return "light"
 			}
 		}
 		// Default to dark for Linux

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1,0 +1,131 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveThemeRespectsOverrides(t *testing.T) {
+	t.Setenv("COLORFGBG", "15;0") // Dark background
+
+	theme := ResolveTheme("auto", "light-custom", "dark-custom")
+	if theme != "dark-custom" {
+		t.Fatalf("expected dark custom theme, got %q", theme)
+	}
+
+	t.Setenv("COLORFGBG", "0;15") // Light background
+	theme = ResolveTheme("auto", "light-custom", "dark-custom")
+	if theme != "light-custom" {
+		t.Fatalf("expected light custom theme, got %q", theme)
+	}
+
+	theme = ResolveTheme("dark", "light-custom", "dark-custom")
+	if theme != "dark" {
+		t.Fatalf("expected explicit theme 'dark', got %q", theme)
+	}
+}
+
+func TestLoadThemeCSSBuiltin(t *testing.T) {
+	css, err := loadThemeCSS("light")
+	if err != nil {
+		t.Fatalf("expected to load built-in theme, got error: %v", err)
+	}
+	if !strings.Contains(css, ".markdown-body") {
+		t.Fatalf("expected CSS to contain .markdown-body")
+	}
+}
+
+func TestLoadThemeCSSCustomFileAndTildeExpansion(t *testing.T) {
+	tempDir := t.TempDir()
+	themePath := filepath.Join(tempDir, "custom.css")
+	if err := os.WriteFile(themePath, []byte(".markdown-body{color:red;}"), 0o644); err != nil {
+		t.Fatalf("failed to write custom theme: %v", err)
+	}
+
+	t.Setenv("HOME", tempDir)
+
+	css, err := loadThemeCSS("~/custom.css")
+	if err != nil {
+		t.Fatalf("expected to load custom theme with tilde, got error: %v", err)
+	}
+	if !strings.Contains(css, "color:red") {
+		t.Fatalf("expected CSS content to be returned, got %q", css)
+	}
+}
+
+func TestLoadThemeCSSMissingFile(t *testing.T) {
+	if _, err := loadThemeCSS("/does/not/exist.css"); err == nil {
+		t.Fatalf("expected error when custom theme missing")
+	}
+}
+
+func TestExtractBackgroundColor(t *testing.T) {
+	css := `.markdown-body { background-color: #0d1117; color: #fff; }`
+	if got := extractBackgroundColor(css); got != "#0d1117" {
+		t.Fatalf("expected background color '#0d1117', got %q", got)
+	}
+
+	css = `.markdown-body { color: #fff; }`
+	if got := extractBackgroundColor(css); got != "" {
+		t.Fatalf("expected empty background color, got %q", got)
+	}
+}
+
+func TestGetMaxWidth(t *testing.T) {
+	tests := map[string]string{
+		"narrow":  "680px",
+		"medium":  "900px",
+		"wide":    "1200px",
+		"full":    "",
+		"800":     "800px",
+		"unknown": "900px",
+	}
+
+	for input, expected := range tests {
+		if got := getMaxWidth(input); got != expected {
+			t.Fatalf("expected width %q for %q, got %q", expected, input, got)
+		}
+	}
+}
+
+func TestToHTMLWrapsOutputWithThemeAndWidth(t *testing.T) {
+	t.Setenv("COLORFGBG", "15;0")
+
+	src := []byte("# Title\n\nContent")
+	html, err := ToHTML(src, "auto", "", "", "narrow")
+	if err != nil {
+		t.Fatalf("ToHTML returned error: %v", err)
+	}
+
+	htmlStr := string(html)
+	if !strings.Contains(htmlStr, "<div class=\"markdown-body\">") {
+		t.Fatalf("expected markdown body wrapper, got %q", htmlStr)
+	}
+
+	css, err := loadThemeCSS("dark")
+	if err != nil {
+		t.Fatalf("failed to load dark theme for comparison: %v", err)
+	}
+	bgColor := extractBackgroundColor(css)
+	if bgColor != "" && !strings.Contains(htmlStr, bgColor) {
+		t.Fatalf("expected background color %q in output", bgColor)
+	}
+	if !strings.Contains(htmlStr, "max-width: 680px") {
+		t.Fatalf("expected narrow width CSS, got %q", htmlStr)
+	}
+}
+
+func TestToANSIProducesRenderableOutput(t *testing.T) {
+	t.Setenv("COLORFGBG", "15;0")
+
+	src := []byte("# Heading")
+	output, err := ToANSI(src, "auto", "", "", 80)
+	if err != nil {
+		t.Fatalf("ToANSI returned error: %v", err)
+	}
+	if !strings.Contains(output, "Heading") {
+		t.Fatalf("expected rendered output to contain heading text, got %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- add comprehensive configuration tests covering defaults, overrides, directory merges, and decoding
- add rendering tests exercising theme resolution, CSS loading, width handling, and markdown conversion
- fix COLORFGBG parsing so automatic theme detection handles numeric backgrounds correctly

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5618c874c832b8fc3b581f8a68b2c