### PR TITLE
Fix GoReleaser archive name templates to remove unwanted spaces

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,8 +79,7 @@ archives:
     ids:
       - mdv-cross
     name_template: >-
-      {{ .ProjectName }}-
-      tui_
+      {{ .ProjectName }}-tui_
       {{- .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
@@ -97,8 +96,7 @@ archives:
     ids:
       - mdv-darwin
     name_template: >-
-      {{ .ProjectName }}-
-      gui_
+      {{ .ProjectName }}-gui_
       {{- .Version }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64


### PR DESCRIPTION
The name_template fields in mdv-tui-archive and mdv-gui-archive were using YAML folding (>-) incorrectly, causing newlines to be converted to spaces:
- mdv- tui_... → mdv-tui_...
- mdv- gui_... → mdv-gui_...

Fixed by placing the suffix on the same line as the hyphen, matching the correct pattern already used in mdv-mac-archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)